### PR TITLE
use the __route value if there is one.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,9 @@
-var DD = require("node-dogstatsd").StatsD;
+var DD = require('node-dogstatsd').StatsD;
 
 module.exports = function (options) {
   var datadog = options.dogstatsd || new DD();
-  var stat = options.stat || "node.express.router";
+  var stat = options.stat || 'node.express.router';
   var tags = options.tags || [];
-  var path = options.path || false;
-  var base_url = options.base_url || false;
   var response_code = options.response_code || false;
 
   return function (req, res, next) {
@@ -18,27 +16,20 @@ module.exports = function (options) {
       res.end = end;
       res.end(chunk, encoding);
 
-      var apiPath = (req.route && req.route.path) || (req.swagger && req.swagger.apiPath);
+      var apiPath = req.__route || (req.route && req.route.path) || (req.swagger && req.swagger.apiPath);
       if (!apiPath) {
         return;
       }
 
-      var baseUrl = (base_url !== false) ? req.baseUrl : '';
-      var statTags = [
-        "route:" + baseUrl + apiPath
-      ].concat(tags);
+      var baseUrl = req.baseUrl;
 
-      if (options.method) {
-        statTags.push("method:" + req.method.toLowerCase());
-      }
+      var statTags = [].concat(tags);
 
-      if (options.protocol && req.protocol) {
-        statTags.push("protocol:" + req.protocol);
-      }
+      statTags.push('route:' + baseUrl + apiPath);
 
-      if (path !== false) {
-        statTags.push("path:" + baseUrl + req.path);
-      }
+      statTags.push('method:' + req.method.toLowerCase());
+
+      statTags.push('protocol:' + req.protocol);
 
       if (options.headers && options.headers.length > 0) {
         options.headers.forEach(function (header) {
@@ -49,7 +40,7 @@ module.exports = function (options) {
       }
 
       if (response_code) {
-        statTags.push("response_code:" + res.statusCode);
+        statTags.push('response_code:' + res.statusCode);
         datadog.increment(stat + '.response_code.' + res.statusCode, 1, statTags);
         datadog.increment(stat + '.response_code.all', 1, statTags);
       }


### PR DESCRIPTION
removed some configurable options as they are not suitable for our use.

should have no real effect until the requests start to contain the value